### PR TITLE
Support digest auth for security, newer and oem cameras that require strict ISAPI, better logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Variables:
 import hikvision.api
 
 # This will use http by default (not https)
+# pass False to the digest_auth parameter of CreateDevice to fallback to basic auth
+# (note that basic auth and http without ssl are inherently insecure)
+# more recent hikvision firmwares default to turning basic auth off
+# (and that's a good idea for security)
 hik_camera = hikvision.api.CreateDevice('192.168.2.5', username='admin', password='12345')
 hik_camera.enable_motion_detection()
 hik_camera.disable_motion_detection()
@@ -77,4 +81,4 @@ pylint hikvision
 coverage run -m unittest discover tests
 ```
 
-Copyright (c) 2015 Finbarr Brady.
+Copyright (c) 2015, 2019 Finbarr Brady.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 Finbarr Brady <https://github.com/fbradyirl>
+# Copyright (c) 2015, 2019 Finbarr Brady <https://github.com/fbradyirl>
 # Licensed under the MIT license.
 
 # Used this guide to create module
@@ -15,7 +15,7 @@ from distutils.core import setup
 
 setup(
     name='hikvision',
-    version='1.2',
+    version='1.3',
     description='Provides a python interface to interact with a hikvision camera',
     author='Finbarr Brady',
     author_email='fbradyirl@users.noreply.github.com',


### PR DESCRIPTION
Work with newer hikvision cameras, including those OEM'd to Hawk Eye surveillance sold through Amazon, by supporting stricter ISAPI URLs and ignoring XML namespace; slightly improved logging, too, to keep many related messages together in a single output so they are not interleaved in home assistant output.  Support Digest authentication, and make it the default.