### PR TITLE
Fixed Content-Type header value type

### DIFF
--- a/hikvision/api.py
+++ b/hikvision/api.py
@@ -268,7 +268,7 @@ class CreateDevice:
         _LOGGING.debug("%s", xml)
 
         headers = DEFAULT_HEADERS
-        headers['Content-Length'] = len(xml)
+        headers['Content-Length'] = str(len(xml))
         headers['Host'] = self._host
         response = requests.put(self.motion_url, auth=self._auth_fn(
             self._username, self._password), data=xml, headers=headers)


### PR DESCRIPTION
In newer `requests` version headers values type must be a `str`. Fixed this to avoid `requests.exceptions.InvalidHeader` at PUT methods.